### PR TITLE
add flavor aliases

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -65,8 +65,8 @@ jobs:
                 [$flavor.flavor_name] + ($flavor.aliases // []) | map({
                   "key": .,
                   "value": {
-                    "build": "ghcr.io/naavre/flavors/naavre-fl-\($flavor.flavor_name)-cell-build:ref_name",
-                    "runtime": "ghcr.io/naavre/flavors/naavre-fl-\($flavor.flavor_name)-cell-runtime:ref_name"
+                    "build": "ghcr.io/naavre/flavors/naavre-fl-\($flavor.flavor_name)-cell-build:${{ github.ref_name }}",
+                    "runtime": "ghcr.io/naavre/flavors/naavre-fl-\($flavor.flavor_name)-cell-runtime:${{ github.ref_name }}"
                   }
                 })
               )] | .[] as $item ireduce([]; . + $item) | from_entries

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -60,8 +60,18 @@ jobs:
       - name: Generate base_image_tags.json
         run: |
           find ./flavors -mindepth 2 -maxdepth 2 -name 'flavor_config.yaml' | \
-            xargs yq ea -o=j '[.] | map({"key": .flavor_name, "value": {"build": "ghcr.io/naavre/flavors/naavre-fl-" + .flavor_name + "-cell-build:${{ github.ref_name }}", "runtime": "ghcr.io/naavre/flavors/naavre-fl-" + .flavor_name + "-cell-runtime:${{ github.ref_name }}"}}) | from_entries' \
-            | tee /tmp/base_image_tags.json
+            xargs yq ea -o=j '
+              [ . as $flavor | . |= (
+                [$flavor.flavor_name] + ($flavor.aliases // []) | map({
+                  "key": .,
+                  "value": {
+                    "build": "ghcr.io/naavre/flavors/naavre-fl-\($flavor.flavor_name)-cell-build:ref_name",
+                    "runtime": "ghcr.io/naavre/flavors/naavre-fl-\($flavor.flavor_name)-cell-runtime:ref_name"
+                  }
+                })
+              )] | .[] as $item ireduce([]; . + $item) | from_entries
+            ' | \
+            tee /tmp/base_image_tags.json
 
       - name: Add base_image_tags.json to release
         uses: svenstaro/upload-release-action@v2

--- a/flavors/vanilla/flavor_config.yaml
+++ b/flavors/vanilla/flavor_config.yaml
@@ -1,3 +1,6 @@
 flavor_name: vanilla
 build_jupyter: True
 free_disk_space: False
+aliases:
+  - python
+  - r


### PR DESCRIPTION
Adds flavor aliases.

For example, the `vanilla` flavor has two aliases, `python` and `r`:

```yaml
# flavors/vanilla/flavor_config.yaml
flavor_name: vanilla
build_jupyter: True
free_disk_space: False
aliases:
  - python
  - r
```

Only one set of images is built:

- `ghcr.io/naavre/flavors/naavre-fl-vanilla-cell-build`
- `ghcr.io/naavre/flavors/naavre-fl-vanilla-cell-runtime`
- `ghcr.io/naavre/flavors/naavre-fl-vanilla-jupyter`

But aliases are created in `base_image_tags.json`:

```json
{
  "vanilla": {
    "build": "ghcr.io/naavre/flavors/naavre-fl-vanilla-cell-build:${{ github.ref_name }}",
    "runtime": "ghcr.io/naavre/flavors/naavre-fl-vanilla-cell-runtime:${{ github.ref_name }}"
  },
  "python": {
    "build": "ghcr.io/naavre/flavors/naavre-fl-vanilla-cell-build:${{ github.ref_name }}",
    "runtime": "ghcr.io/naavre/flavors/naavre-fl-vanilla-cell-runtime:${{ github.ref_name }}"
  },
  "r": {
    "build": "ghcr.io/naavre/flavors/naavre-fl-vanilla-cell-build:${{ github.ref_name }}",
    "runtime": "ghcr.io/naavre/flavors/naavre-fl-vanilla-cell-runtime:${{ github.ref_name }}"
  }
}
```

This allows us to maintain and build a single `vanilla` flavor, but still `r` and `python` cell base images. This avoids confusing users and breaking compatibility with the `NaaVRE-containerizer-service` which assumes that these two base images exist ([app/models/notebook_data.py:NotebookData.set_base_image_name](https://github.com/NaaVRE/NaaVRE-containerizer-service/blob/3c1a21765a0688d19c0da9a8acb6c1ae7a262b05/app/models/notebook_data.py#L29-L37)).