### PR TITLE
Add Jupyter Lab extensions

### DIFF
--- a/docker/jupyter.requirements.txt
+++ b/docker/jupyter.requirements.txt
@@ -1,3 +1,8 @@
 NaaVRE-communicator-jupyterlab==0.2.4
 NaaVRE-containerizer-jupyterlab==0.3.4
 NaaVRE-workflow-jupyterlab==0.3.0
+ipywidgets>=8.1.7
+jupyter-archive>=3.4.0
+jupyterlab-git>=0.51.2
+nbgitpuller>=1.2.2
+voila>=0.5.7


### PR DESCRIPTION
Add 3rd-party Jupyter Lab extensions that were installed in [QCDIS/NaaVRE](https://github.com/QCDIS/NaaVRE):

- ipywidgets
- jupyter-archive
- jupyterlab-git
- nbgitpuller
- voila