### PR TITLE
Add catalogue frontend and update jupyter requirements

### DIFF
--- a/docker/jupyter.requirements.txt
+++ b/docker/jupyter.requirements.txt
@@ -1,4 +1,5 @@
 NaaVRE-catalogue-jupyterlab==0.1.2
+NaaVRE-communicator-jupyterlab==0.3.3
 NaaVRE-containerizer-jupyterlab==0.4.2
 NaaVRE-workflow-jupyterlab==0.4.9
 ipywidgets>=8.1.7


### PR DESCRIPTION
This adds [NaaVRE-catalogue-jupyterlab v0.1.2](https://github.com/NaaVRE/NaaVRE-catalogue-jupyterlab/releases/tag/v0.1.2), which requires [NaaVRE-catalogue-service v0.5.0-alpha.1](https://github.com/NaaVRE/NaaVRE-catalogue-service/releases/tag/v0.5.0-alpha.1) or later. 