### PR TITLE
Bump jupyter extension versions

### DIFF
--- a/docker/jupyter.requirements.txt
+++ b/docker/jupyter.requirements.txt
@@ -1,7 +1,7 @@
-NaaVRE-catalogue-jupyterlab==0.1.3
+NaaVRE-catalogue-jupyterlab==0.2.0
 NaaVRE-communicator-jupyterlab==0.3.3
-NaaVRE-containerizer-jupyterlab==0.4.3
-NaaVRE-workflow-jupyterlab==0.5.1
+NaaVRE-containerizer-jupyterlab==0.5.0
+NaaVRE-workflow-jupyterlab==0.6.0
 ipywidgets>=8.1.7
 jupyter-archive>=3.4.0
 jupyterlab-git>=0.51.2


### PR DESCRIPTION
NaaVRE-catalogue-jupyterlab to 0.2.0
NaaVRE-containerizer-jupyterlab to 0.5.0
NaaVRE-workflow-jupyterlab to 0.6.0

These new versions require NaaVRE-catalogue-service v0.6.0 (https://github.com/NaaVRE/NaaVRE-catalogue-service/releases/tag/v0.6.0)