### PR TITLE
Bump NaaVRE-workflow-jupyterlab to 0.6.2

### DIFF
--- a/docker/jupyter.requirements.txt
+++ b/docker/jupyter.requirements.txt
@@ -1,7 +1,7 @@
 NaaVRE-catalogue-jupyterlab==0.2.0
 NaaVRE-communicator-jupyterlab==0.3.3
 NaaVRE-containerizer-jupyterlab==0.5.1
-NaaVRE-workflow-jupyterlab==0.6.1
+NaaVRE-workflow-jupyterlab==0.6.2
 ipywidgets>=8.1.7
 jupyter-archive>=3.4.0
 jupyterlab-git>=0.51.2


### PR DESCRIPTION
https://github.com/NaaVRE/NaaVRE-workflow-jupyterlab/releases/tag/v0.6.2